### PR TITLE
20210906 various Ruby file fixes along with shell script changes.

### DIFF
--- a/alt-cannadic/modify-cannadic.rb
+++ b/alt-cannadic/modify-cannadic.rb
@@ -84,11 +84,6 @@ end
 # main
 # ==============================================================================
 
-`wget -nc https://ja.osdn.net/projects/alt-cannadic/downloads/50881/alt-cannadic-110208.tar.bz2`
-`rm -rf alt-cannadic-110208`
-`tar xf alt-cannadic-110208.tar.bz2`
-`mv alt-cannadic-110208/{gcanna.ctd,g_fname.ctd} .`
-
 $filename = "gcanna.ctd"
 $dicname = "mozcdic-altcanna.txt"
 modify_cannadic

--- a/edict/modify-edict2.rb
+++ b/edict/modify-edict2.rb
@@ -108,9 +108,6 @@ end
 # main
 # ==============================================================================
 
-`rm -f edict2`
-`wget -nc http://ftp.monash.edu/pub/nihongo/edict2.gz`
-`gzip -dk edict2.gz`
 $filename = "edict2"
 $dicname = "mozcdic-edict2.txt"
 

--- a/jawiki-all-titles/count-jawiki-titles.rb
+++ b/jawiki-all-titles/count-jawiki-titles.rb
@@ -61,8 +61,6 @@ end
 # main
 # ==============================================================================
 
-`rm -f jawiki-latest-all-titles-in-ns0`
-`wget -nc https://dumps.wikimedia.org/jawiki/latest/jawiki-latest-all-titles-in-ns0.gz`
 $filename = "jawiki-latest-all-titles-in-ns0.gz"
 $dicname = "jawiki-latest-all-titles-in-ns0.counts"
 

--- a/jawiki-articles/get-entries-from-jawiki-articles.rb
+++ b/jawiki-articles/get-entries-from-jawiki-articles.rb
@@ -223,8 +223,6 @@ end
 jawiki = "jawiki-latest-pages-articles.xml.bz2"
 mozcdic = "jawiki-ut.txt"
 
-`wget -nc https://dumps.wikimedia.org/jawiki/latest/#{jawiki}`
-
 reader = Bzip2::FFI::Reader.open(jawiki)
 $dicfile = File.new(mozcdic, "w")
 core_num = `grep cpu.cores /proc/cpuinfo`.chomp.split(": ")[-1].to_i - 1

--- a/neologd/convert-neologd-to-mozc.rb
+++ b/neologd/convert-neologd-to-mozc.rb
@@ -133,14 +133,11 @@ end
 # ==============================================================================
 # main
 # ==============================================================================
-
 require 'open-uri'
 url = "https://github.com/neologd/mecab-ipadic-neologd/tree/master/seed"
 neologdver = URI.open(url).read.split("mecab-user-dict-seed.")[1]
 neologdver = neologdver.split(".csv.xz")[0]
 
-`wget -nc https://github.com/neologd/mecab-ipadic-neologd/raw/master/seed/mecab-user-dict-seed.#{neologdver}.csv.xz`
-`7z x -aos mecab-user-dict-seed.#{neologdver}.csv.xz`
 $filename = "mecab-user-dict-seed.#{neologdver}.csv"
 $dicname = "mozcdic-neologd.txt"
 

--- a/nicoime/modify-nicoime.rb
+++ b/nicoime/modify-nicoime.rb
@@ -85,9 +85,6 @@ end
 # main
 # ==============================================================================
 
-`wget -nc http://public.s3.tkido.com.s3-website-ap-northeast-1.amazonaws.com/nicoime.zip`
-`rm -f nicoime_*.txt`
-`7z x nicoime.zip`
 $filename = "nicoime_msime.txt"
 $dicname = "mozcdic-nicoime.txt"
 

--- a/skk/modify-skkdic.rb
+++ b/skk/modify-skkdic.rb
@@ -73,9 +73,6 @@ end
 # main
 # ==============================================================================
 
-`wget -nc http://openlab.jp/skk/dic/SKK-JISYO.L.gz`
-`rm -f SKK-JISYO.L`
-`gzip -dk SKK-JISYO.L.gz`
 $filename = "SKK-JISYO.L"
 $dicname = "mozcdic-skkdic.txt"
 

--- a/src/make-dictionaries.bash
+++ b/src/make-dictionaries.bash
@@ -16,7 +16,7 @@ sudachidict="true"
 # Make each dictionary
 # ==============================================================================
 
-function clean() {
+clean() {
 dirs -c
 echo ":: Cleaning up working directory ..."
 find "$PWD" -name "mozcdic-ut.txt" -delete
@@ -26,7 +26,7 @@ find .. -type f \( -name "*.zip" -o -name "*.gz" \) -delete
 find ../mozc -type d -name "mozc-master" -exec rm -r '{}' \;
 }
 
-function get-mozc-dict-defs() {
+get-mozc-dict-defs() {
 echo ":: Fetching the latest mozc dictionary definitions ..."
 pushd ../mozc &>/dev/null || exit
 # https://stackoverflow.com/a/18194523
@@ -37,7 +37,7 @@ rm -rf dictionary_oss
 popd &>/dev/null || exit
 }
 
-function get-and-process-alt-cannadic() {
+get-and-process-alt-cannadic() {
 echo ":: Checking for revised canna dictionary file ..."
 # acc = Academic Computer Club, Umeå University ウメオ, スウェーデン
 # bfsu = 北京外国語大学 北京, 中国
@@ -93,7 +93,7 @@ if [[ $altcannadic = "true" ]];
 fi
 } 
 
-function get-and-process-edict() {
+get-and-process-edict() {
 if [[ $edict = "true" ]]; 
   then
   echo ":: Checking for Jim Breen's EDICT2 file ..."
@@ -112,7 +112,7 @@ if [[ $edict = "true" ]];
 fi
 }
 
-function get-and-process-jawiki-titles() {
+get-and-process-jawiki-titles() {
 local _titles_file="jawiki-latest-all-titles-in-ns0"
 local _md5sum_file="jawiki-latest-md5sums.txt"
 local _url="https://dumps.wikimedia.org/jawiki/latest"
@@ -138,7 +138,7 @@ fi
 popd &>/dev/null || exit
 }
 
-function get-and-process-jawiki-articles() {
+get-and-process-jawiki-articles() {
 local _articles_file="jawiki-latest-pages-articles.xml.bz2"
 local _md5sum_file="jawiki-latest-md5sums.txt"
 local _url="https://dumps.wikimedia.org/jawiki/latest"
@@ -169,7 +169,7 @@ if [[ $jawikiarticles = "true" ]]; then
 fi
 }
 
-function process-jinmei() {
+process-jinmei() {
 if [[ $jinmeiut = "true" ]]; 
         then
                 echo ":: Processing jinmei for Japanese names ..."
@@ -180,7 +180,7 @@ if [[ $jinmeiut = "true" ]];
 fi
 }
 
-function get-and-process-neologd() {
+get-and-process-neologd() {
 local _url="https://github.com/neologd/mecab-ipadic-neologd/raw/master/seed"
 local _file="mecab-user-dict-seed"
 local _version="20200910"
@@ -202,7 +202,7 @@ if [[ $neologd = "true" ]]; then
 fi
 }
 
-function get-and-process-nicoime() {
+get-and-process-nicoime() {
 local _filename="nicoime.zip"
 local _url="http://public.s3.tkido.com.s3-website-ap-northeast-1.amazonaws.com"
 if [[ $nicoime = "true" ]]; 
@@ -224,7 +224,7 @@ if [[ $nicoime = "true" ]];
 fi
 }
 
-function get-and-process-skk() {
+get-and-process-skk() {
 local _filename="SKK-JISYO.L.gz"
 local _url="http://openlab.jp/skk/dic"
 if [[ $skk = "true" ]]; 
@@ -245,7 +245,7 @@ if [[ $skk = "true" ]];
 fi
 }
 
-function get-and-process-sudachidict() {
+get-and-process-sudachidict() {
 local _filename="core_lex.csv"
 local
 _url="https://github.com/WorksApplications/SudachiDict/raw/develop/src/main/text/"
@@ -265,17 +265,17 @@ if [[ $sudachidict = "true" ]];
             curl --output "not$_filename" --location "$_url/not$_filename"
         fi
         echo ":: Processing Sudachi Dictionary files ..."
-        ruby convert-sudachiduct-to-mozc.rb
+        ruby convert-sudachidict-to-mozc.rb
         ruby ../src/filter-entries.rb mozcdic-sudachidict-*.txt
         cat mozcdic-sudachidict-*.txt >> ../src/mozcdic-ut.txt
         popd &>/dev/null || exit
 fi
 }
 
-function fetch_and_process-Japan-postcode() {
+fetch_and_process-Japan-postcode() {
 local _filename="ken_all.zip"
 local _url="https://www.post.japanpost.jp/zipcode/dl/kogaki/zip"
-echo ":: Checking Japan postal codes file  ..."
+echo ":: Checking for Japan postal codes file  ..."
 pushd "../zipcode" &>/dev/null || exit
 find "$PWD" -type f -name "KEN_ALL.CSV" -delete
         if ! [ -f "$_filename" ];
@@ -292,7 +292,7 @@ find "$PWD" -type f -name "KEN_ALL.CSV" -delete
 popd &>/dev/null || exit
 }
 
-function extract_new_entry_and_apply_jawiki_costs() {
+extract_new_entry_and_apply_jawiki_costs() {
 cd ../src/
 
 
@@ -307,7 +307,7 @@ rm -f ../mozcdic*-ut-*.txt
 mv mozcdic-ut.txt.extracted ../mozcdic-ut-$UTDICDATE.txt
 }
 
-function make_mozcdic-ut_pkg() {
+make_mozcdic-ut_pkg() {
 # ==============================================================================
 # Make a mozcdic-ut package
 # ==============================================================================
@@ -321,7 +321,7 @@ rsync -av mozcdic-ut-dev/* mozcdic-ut-$UTDICDATE --exclude=id.def \
 rm -f mozcdic-ut-$UTDICDATE/*/mozcdic*.txt*
 }
 
-function main() {
+main() {
 clean
 get-mozc-dict-defs
 get-and-process-alt-cannadic

--- a/sudachidict/convert-sudachidict-to-mozc.rb
+++ b/sudachidict/convert-sudachidict-to-mozc.rb
@@ -148,9 +148,6 @@ end
 # main
 # ==============================================================================
 
-`wget -nc https://github.com/WorksApplications/SudachiDict/raw/develop/src/main/text/core_lex.csv`
-`wget -nc https://github.com/WorksApplications/SudachiDict/raw/develop/src/main/text/notcore_lex.csv`
-
 $filename = "core_lex.csv"
 $dicname = "mozcdic-sudachidict-core.txt"
 convert_sudachidict_to_mozc

--- a/zipcode/fix-ken_all.rb
+++ b/zipcode/fix-ken_all.rb
@@ -69,9 +69,6 @@ end
 # main
 # ==============================================================================
 
-`rm -f KEN_ALL.CSV`
-`wget -nc https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip`
-`unzip ken_all.zip`
 $filename = "KEN_ALL.CSV"
 $dicname = "KEN_ALL.CSV.fixed"
 fix_ken_all


### PR DESCRIPTION
alt-cannadic/modify-cannadic.rb, edict/modify-edict2.rb,
jawiki-all-titles/count-jawiki-titles.rb,
jawiki-articles/get-entries-from-jawiki-articles.rb,
neologd/convert-neologd-to-mozc.rb, nicoime/modify-nicoime.rb,
skk/modify-skkdic.rb, zipcode/fix-ken_all.rb,
sudachidict/convert-sudachidict-to-mozc.rb:
  * Deleted download capability.
  * ダウンロード機能を消しました。

sudachidict/convert-sudachiduct-to-mozc.rb:
  * File renamed to convert-sudachidict-to-mozc.rb.
  * convert-sudachidict-to-mozc.rb名前を変化しました。

make-dictionaries.bash:
  * "function" word removed.
  * sudachidict: Ruby file renamed accordingly.
  * zipcode: "Checking Japan ..." to "Checking for Japan ..."
  * "function" 単語を消しました。
  * sudachidict: Rubyファイル名前を変化しました。
  * zipcode: "Checking Japan ..."から"Checking for Japan
    ..."まで進歩詳細を変化しました。